### PR TITLE
Recipes can now have items that do not get subtracted from inventory

### DIFF
--- a/client/services/vui.lua
+++ b/client/services/vui.lua
@@ -56,9 +56,8 @@ RegisterNUICallback('vorp-openinv', function(args, cb)
 end)
 
 RegisterNUICallback('vorp-craftevent', function(args, cb)
-
     local count = tonumber(args.quantity)
-    if count ~= nil and count ~= 'close' and count ~= '' and count ~= 0 then
+    if count ~= nil and count ~= 'close' and count ~= '' and count > 0 then
         TriggerServerEvent('vorp:startcrafting', args.craftable, count, args.location)
         cb('ok')
     else

--- a/config.lua
+++ b/config.lua
@@ -9,7 +9,8 @@ Config.Keys = {
 
 -- Options: s, m, l
 Config.Styles = {
-    fontSize = 'm'
+    fontSize = 'm',
+    descriptionsidebar = true
 }
 
 Config.Commands = {

--- a/config.lua
+++ b/config.lua
@@ -149,11 +149,13 @@ Config.Crafting = {
         Items = {
             {
                 name = "meat",
-                count = 1
+                count = 1,
+                take = true -- This determines if recipe items will be taken from inventory after crafting. If ommited, it will default to true.
             },
             {
                 name = "salt",
-                count = 1
+                count = 1,
+                take = false -- This determines if recipe items will be taken from inventory after crafting. If ommited, it will default to true.
             }
         },
         Reward = {
@@ -168,7 +170,8 @@ Config.Crafting = {
         UseCurrencyMode = false,
         CurrencyType = 0, -- 0 = money, 1 = gold
         Category = "food",
-        Animation = 'knifecooking'
+        Animation = 'knifecooking',
+        TakeItems = true -- This determines if recipe items will be taken from inventory after crafting. If ommited, it will default to true.
     },
     {
         Text = "Seasoned Small Game ",

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -42,7 +42,7 @@ dependencies {
 
 
 --dont touch
-version '1.4'
+version '1.5'
 vorp_checker 'yes'
 vorp_name '^4Resource version Check^3'
 vorp_github 'https://github.com/VORPCORE/vorp_crafting'

--- a/server/server.lua
+++ b/server/server.lua
@@ -94,8 +94,13 @@ AddEventHandler('vorp:startcrafting', function(craftable, countz)
                     VorpInv.canCarryWeapons(_source, 1, function(canCarryWeapons)
                         if canCarryWeapons  then
                             -- Delete items to crafting
-                            for index, item in pairs(crafting.Items) do
-                                VorpInv.subItem(_source, item.name, item.count * countz)
+
+                            if crafting.TakeItems == nil or crafting.TakeItems == true then
+                                for index, item in pairs(crafting.Items) do
+                                    if item.take == nil or item.take == true then
+                                        VorpInv.subItem(_source, item.name, item.count * countz)
+                                    end
+                                end
                             end
 
                             -- Give weapons from the crafting list
@@ -124,9 +129,13 @@ AddEventHandler('vorp:startcrafting', function(craftable, countz)
                     local invAvailable = VorpInv.canCarryItems(_source, addcount - subcount)
                     if crafting.UseCurrencyMode or (invAvailable and cancarry) then
 
-                        -- Loop through and remove each item
-                        for index, item in pairs(crafting.Items) do
-                            VorpInv.subItem(_source, item.name, item.count * countz)
+                        if crafting.TakeItems == nil or crafting.TakeItems == true then
+                            -- Loop through and remove each item
+                            for index, item in pairs(crafting.Items) do
+                                if item.take == nil or item.take == true then
+                                    VorpInv.subItem(_source, item.name, item.count * countz)
+                                end
+                            end
                         end
 
                         -- Give crafted item(s) to player

--- a/ui/app.js
+++ b/ui/app.js
@@ -7,7 +7,12 @@ createApp({
       visible: false,
       showInput: false,
       style: {
-        fontSize: 'm'
+        fontSize: 'm',
+        descriptionsidebar: null
+      },
+      desc: {
+        data: null,
+        show: false
       },
       job: null,
       language: {},
@@ -49,7 +54,9 @@ createApp({
       testCategory: [
         {
           ident: 'food', 
-          text: 'Craft Food'
+          text: 'Craft Food',
+          Job: 0,
+          Location: 0
         }
       ]
     };
@@ -66,7 +73,8 @@ createApp({
         categories: this.testCategory,
         crafttime: 15000,
         style: {
-          fontSize: 'm'
+          fontSize: 'm',
+          descriptionsidebar: true
         },
         language: {
           InputHeader: 'How many {{msg}} you want to craft',
@@ -116,6 +124,10 @@ createApp({
     },
     InputCraftText() {
       return  this.activeCraftable.Text && this.language.InputHeader ? this.language.InputHeader.replace('{{msg}}', this.activeCraftable.Text) : ''
+    },
+    Ingredients() {
+      if (this.desc.show == false) return ''
+      return this.desc.data.Desc.replace('Recipe: ', '').replace('Recipe ', '').split(',')
     }
   },
   methods: {
@@ -143,6 +155,10 @@ createApp({
         this.currentRoute = 'home'
         this.closeView()
       }
+    },
+    toggleDesc(ing, state) {
+      this.desc.show = state
+      this.desc.data = ing
     },
     animationPlaying() {
       this.visible = false

--- a/ui/index.html
+++ b/ui/index.html
@@ -19,16 +19,23 @@
             </div>
   
             <div class="craftable-wrap" v-for="(cata, index) in Object.keys(consumables)" :key="'catitems'+index"   v-show="currentRoute == cata" >
-              <div class="bcc-button" v-for="(it, index) in consumables[cata]" @click="handleItemClick(it)">
+              <div class="bcc-button" v-for="(it, index) in consumables[cata]" @click="handleItemClick(it)" @mouseover="toggleDesc(it, true)" @mouseleave="toggleDesc(null, false)">
                 <div class="button-content">
                   <div class="text">{{it.Text}}</div>
                   <div class="subtext" v-if="it.SubText">{{it.SubText}}</div>
                 </div>
-                <div class="description">
+                <div v-if="style.descriptionsidebar == false" class="description">
                   <div>{{it.Desc}}</div>
                 </div>
               </div>
               <div class="bcc-button" @click="currentRoute = 'home'"><span class="statictext">{{language.BackButton}}</span></div>
+            </div>
+          </div>
+
+          <div class="ing-tile" v-if="desc.show && style.descriptionsidebar == true">
+            <h2>Ingredients</h2>
+            <div v-for="(ing, index) in Ingredients" :key="'desc'+index">
+              {{ing}}
             </div>
           </div>
         </div>

--- a/ui/style.css
+++ b/ui/style.css
@@ -139,6 +139,19 @@ h2 {
   transform: translate(-50%, -50%);
 }
 
+.ing-tile {
+  position: absolute;
+  top: 0;
+  left: 100%;
+  background-image: url(assets/inkroller.png);
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 100% 100%;
+  white-space: nowrap;
+  min-height: 160px;
+  padding: 20px;
+}
+
 .text {
   padding-top: 8px;
 }

--- a/version
+++ b/version
@@ -1,3 +1,8 @@
+<1.5>
+- Exploit fixed
+- New config for allowing items to stay in inventory on use
+- New campfireprops config that allows custom titles
+- New ingredients UI!
 <1.4>
 - Bugfixes around player crashing on character select
 - Migrated to vorp_progressbar


### PR DESCRIPTION
**What this changes:**
1. Individual recipe items now have a `take` key that determines if the recipe ingredient will be taken from inventory when crafted
2. Recipe items now have a `TakeItem` key that determines if all recipe ingredients will be not taken from inventory when crafted


Example: 

```lua
{
        Text = "Meat Bfast ",
        SubText = "InvMax = 10",
        Desc = "Recipe: 1x Meat, 1x Salt",
        Items = {
            {
                name = "meat",
                count = 1,
                take = true -- This determines if recipe items will be taken from inventory after crafting. If ommited, it will default to true.
            },
            {
                name = "salt",
                count = 1,
                take = false -- This determines if recipe items will be taken from inventory after crafting. If ommited, it will default to true.
            }
        },
        Reward = {
            {
                name = "consumable_breakfast",
                count = 1
            }
        },
        Type = "item", -- indicate if it is 'weapon' or 'item'
        Job = 0, -- set to 0 to allow any jobs, or like { "butcher" } to job restriction
        Location = 0, -- set to 0 to allow any locations from Config.Locations, or like { "butcher" } to job restriction
        UseCurrencyMode = false,
        CurrencyType = 0, -- 0 = money, 1 = gold
        Category = "food",
        Animation = 'knifecooking',
        TakeItems = true -- This determines if recipe items will be taken from inventory after crafting. If ommited, it will default to true.
    },
```