### PR TITLE
Don't show crafting prompt to dead folks

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -49,7 +49,7 @@ Citizen.CreateThread(function()
             local blipcount = 0
             for k, loc in ipairs(Config.Locations) do
                 local jobcheck = CheckJob(loc.Job)
-                if jobcheck and uiopen == false then
+                if jobcheck and uiopen == false and IsEntityDead(player) == false then
                     if loc.Blip and blipsadded == false and loc.Blip.enable then
                         blipcount = blipcount + 1
                         Blips.addBlipForCoords(k, loc.name, loc.Blip.Hash, loc.x, loc.y, loc.z)

--- a/client/client.lua
+++ b/client/client.lua
@@ -25,7 +25,7 @@ Citizen.CreateThread(function()
             if  Config.CraftingPropsEnabled then
                 local propjobcheck = CheckJob(Config.CampfireJobLock)
                 for k, v in pairs(Config.CraftingProps) do
-                    if propjobcheck and iscrafting == false and uiopen == false then
+                    if propjobcheck and iscrafting == false and uiopen == false and IsEntityDead(player) == false then
                         if type(v.prop) == "table" then
                             for kk, vv in pairs(v.prop) do
                                 campfire = DoesObjectOfTypeExistAtCoords(Coords.x, Coords.y, Coords.z, Config.Distances.campfire, GetHashKey(vv), 0)


### PR DESCRIPTION
# Pull request template
> [!IMPORTANT]
> Please complete all fields. PRs will not be merged if any fields are incomplete. Be respectful, and keep in mind that it may take some time for your PR to be reviewed.
>
> Bear in mind refactors are up to the developers and not it's contributors after all we are the ones giving support when needed. if they are big changes I suggest you to release it under your name instead.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Motive for This Pull Request
Downed folks can't use the respawn UI prompt if they go down next to a crafting location.

### Provide a brief explanation of why these changes are being proposed and what they aim to achieve.
This fixes people being unable to respawn when they go down next to a crafting location, and also prevents them from opening the crafting UI.

### Explain the necessity of these changes and how they will impact the framework or its users.
Necessary to prevent people from getting stuck in a downed state if they die next to a crafting location or prompt.

### Please describe the tests you have conducted to verify your changes. Provide instructions so we can reproduce these tests. Also, list any relevant details for your test configuration.

- [x] Tested with latest vorp scripts
- [x] Tested with latest artifacts

## Notes if any
None
