### PR TITLE
fix: campfire props not detecting all entries in the props table

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -24,8 +24,8 @@ CreateThread(function()
                     if type(v.prop) == "table" then
                         for kk, vv in pairs(v.prop) do
                             campfire = DoesObjectOfTypeExistAtCoords(Coords.x, Coords.y, Coords.z,   Config.Distances.campfire, GetHashKey(vv), false)
+                            if campfire then break end
                         end
-                        if not campfire then break end
                     else
                         local prop = v.prop --[[@as string]]
                         campfire = DoesObjectOfTypeExistAtCoords(Coords.x, Coords.y, Coords.z, Config.Distances.campfire,


### PR DESCRIPTION
# Pull request template
> [!IMPORTANT]
> Please complete all fields. PRs will not be merged if any fields are incomplete. Be respectful, and keep in mind that it may take some time for your PR to be reviewed.
>
> Bear in mind refactors are up to the developers and not it's contributors after all we are the ones giving support when needed. if they are big changes I suggest you to release it under your name instead.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Motive for This Pull Request
Fixing the campfire detection not detecting all entries in the props table

### Provide a brief explanation of why these changes are being proposed and what they aim to achieve.
Prior to this fix, the variable `campfire` gets set to the value of `DoesObjectOfTypeExistAtCoords()` and doesn't break the loop afterwards, regardless of result, effectively making only the last prop in the table meaningful. It also breaks after the first set of props. This fixes that too.

### Explain the necessity of these changes and how they will impact the framework or its users.
This will allow people to use a full table of props for a campfire.

### Please describe the tests you have conducted to verify your changes. Provide instructions so we can reproduce these tests. 
Before changing your local copy to my commit, use this Config entry and test at the oven in the Valentine Saloon or the Campfire right outside of Valentine. You'll find neither work until you integrate my commit.
```Config.CraftingProps = {
  {
    title = "Campfire",
    prop = { "s_campfireset03x", "p_campfire01x", "p_campfirecombined01x", "p_campfirefresh01x", "p_fireplacelogs01x", "p_campfire04x", "p_campfire05x", "p_campfire02x", "p_campfirecombined02x", "p_campfirecombined03x", "p_campfirecombined04x", "p_campfirecook02x", "p_campfire_win2_01x", "p_craftingpot01x", }
  },
  {
    title = "Oven",
    prop = { "p_furnace01x", "p_stove04x", "p_woodstove01x" }
  }
}```

- [x] Tested with latest vorp scripts
- [x] Tested with latest artifacts

## Notes if any
explanation field
