### PR TITLE
Craft UI: item icons & quantity modal close; server checks

### DIFF
--- a/client/services/vui.lua
+++ b/client/services/vui.lua
@@ -2,44 +2,69 @@ uiopen = false
 
 VUI = {}
 
--- openUI
-VUI.OpenUI = function(location)
-    local allText = _all()
+local Core = exports.vorp_core:GetCore()
+local LabelsLUT = {}
+local fetchedOnce = false
 
-    if allText then
-        uiopen = true
-        local Categories = {}
+local function fetchLabelsLUTSync()
+    local ok, result = pcall(function()
+        return Core.Callback.TriggerAwait("vorp_crafting:GetLabelLUT")
+    end)
 
-        if location.Categories == 0 or location.Categories == nil then
-            Categories = Config.Categories
-        else
-            for keyloc, loccat in pairs(location.Categories) do
-                for keycat, cat in ipairs(Config.Categories) do
-                    if loccat == cat.ident then
-                        Categories[#Categories + 1] = cat
-                        break
-                    end
-                end
-            end
+    if ok and type(result) == "table" then
+        LabelsLUT = result
+    else
+        if not fetchedOnce then
+            print("^3[CRAFTING]^7 Failed to fetch LabelLUT (will retry on next open).")
+            fetchedOnce = true
         end
-
-        if Config.KneelingAnimation then
-            Animations.forceRestScenario(true)
-        end
-        SendNUIMessage({
-            type = 'vorp-craft-open',
-            craftables = Config.Crafting,
-            categories = Categories,
-            crafttime = Config.CraftTime,
-            style = Config.Styles,
-            language = allText,
-            location = location,
-            job = LocalPlayer.state.Character.Job
-        })
-        SetNuiFocus(true, true)
     end
 end
 
+-- === Open UI ===
+VUI.OpenUI = function(location)
+    local allText = _all()
+    if not allText then return end
+
+    uiopen = true
+
+    -- Collect categories for this location
+    local Categories = {}
+    if not location or location.Categories == 0 or location.Categories == nil then
+        Categories = Config.Categories
+    else
+        for _, ident in pairs(location.Categories) do
+            for _, cat in ipairs(Config.Categories) do
+                if ident == cat.ident then
+                    Categories[#Categories+1] = cat
+                    break
+                end
+            end
+        end
+    end
+
+    if Config.KneelingAnimation then
+        Animations.forceRestScenario(true)
+    end
+
+    -- Ensure LUT is available
+    fetchLabelsLUTSync()
+
+    SendNUIMessage({
+        type       = "vorp-craft-open",
+        craftables = Config.Crafting,
+        categories = Categories,
+        crafttime  = Config.CraftTime,
+        style      = Config.Styles,
+        language   = allText,
+        location   = location,
+        job        = LocalPlayer.state.Character.Job,
+        labels     = LabelsLUT,
+    })
+    SetNuiFocus(true, true)
+end
+
+-- === Animations / Focus handling ===
 VUI.Animate = function()
     SendNUIMessage({
         type = 'vorp-craft-animate'
@@ -51,6 +76,7 @@ VUI.Refocus = function()
     SetNuiFocus(true, true)
 end
 
+-- === NUI Callbacks ===
 RegisterNUICallback('vorp-craft-close', function(args, cb)
     SetNuiFocus(false, false)
     uiopen = false

--- a/config.lua
+++ b/config.lua
@@ -4,6 +4,8 @@ Config.defaultlang = "en_lang"
 
 Config.DevMode = false -- enable this if you want to make testes, dont leave true in live servers
 
+Config.CraftingDiagnostics = false -- if true: on startup checks all crafting recipes for missing DB items, weapons, PNG icons, and malformed entries
+
 --Webhook move to server.lua line 26 
 
 Config.CampFireItem = "campfire"
@@ -1085,3 +1087,4 @@ Config.Animations = {
         type = 'standard'
     }
 }
+

--- a/config.lua
+++ b/config.lua
@@ -6,7 +6,8 @@ Config.DevMode = false -- enable this if you want to make testes, dont leave tru
 
 Config.CraftingDiagnostics = false -- if true: on startup checks all crafting recipes for missing DB items, weapons, PNG icons, and malformed entries
 
---Webhook move to server.lua line 26 
+-- Webhook settings
+Config.CraftingWebhook = ""  -- put your Discord webhook here (leave empty to disable logging)
 
 Config.CampFireItem = "campfire"
 
@@ -1087,4 +1088,5 @@ Config.Animations = {
         type = 'standard'
     }
 }
+
 

--- a/config.lua
+++ b/config.lua
@@ -6,8 +6,7 @@ Config.DevMode = false -- enable this if you want to make testes, dont leave tru
 
 Config.CraftingDiagnostics = false -- if true: on startup checks all crafting recipes for missing DB items, weapons, PNG icons, and malformed entries
 
--- Webhook settings
-Config.CraftingWebhook = ""  -- put your Discord webhook here (leave empty to disable logging)
+--Webhook move to server.lua line 26 
 
 Config.CampFireItem = "campfire"
 
@@ -1088,5 +1087,6 @@ Config.Animations = {
         type = 'standard'
     }
 }
+
 
 

--- a/server/server.lua
+++ b/server/server.lua
@@ -186,3 +186,178 @@ RegisterNetEvent('vorp:startcrafting', function(craftable, countz)
         end
     end
 end)
+
+-- ===== Crafting sanity check (DB + images) =====
+local INV_RES_NAME = GetConvar("vorp_inventory_resource", "vorp_inventory")
+local INV_RES_PATH = GetResourcePath(INV_RES_NAME) -- absolute path to resource folder (nil if resource not found)
+local DB_MODE = "none"
+
+-- Detect DB adapter and expose a unified checker
+local function db_item_exists(name)
+    if not name or name == "" then return false end
+    local sql = "SELECT 1 FROM items WHERE item = ? LIMIT 1"
+
+    -- oxmysql (preferred)
+    if exports.oxmysql then
+        if exports.oxmysql.scalarSync then
+            DB_MODE = "oxmysql:scalarSync"
+            local ok, val = pcall(function()
+                return exports.oxmysql:scalarSync(sql, { name })
+            end)
+            if ok then return val ~= nil end
+        elseif exports.oxmysql.executeSync then
+            DB_MODE = "oxmysql:executeSync"
+            local ok, rows = pcall(function()
+                return exports.oxmysql:executeSync(sql, { name })
+            end)
+            if ok then return rows and rows[1] ~= nil end
+        end
+    end
+
+    -- mysql-async / ghmattimysql Sync
+    if MySQL and MySQL.Sync then
+        if MySQL.Sync.fetchScalar then
+            DB_MODE = "mysql-async:fetchScalar"
+            local ok, val = pcall(function()
+                return MySQL.Sync.fetchScalar(sql, { name })
+            end)
+            if ok then return val ~= nil end
+        elseif MySQL.Sync.fetchAll then
+            DB_MODE = "mysql-async:fetchAll"
+            local ok, rows = pcall(function()
+                return MySQL.Sync.fetchAll(sql, { name })
+            end)
+            if ok then return rows and rows[1] ~= nil end
+        end
+    end
+
+    return false
+end
+
+local function file_exists(path)
+    if not path then return false end
+    local f = io.open(path, "rb")
+    if f then f:close() return true end
+    return false
+end
+
+local function image_exists(name)
+    if not INV_RES_PATH then return nil end-- nil => we cannot check (resource not found), we make no noise
+    local p = ("%s/html/img/items/%s.png"):format(INV_RES_PATH, name)
+    return file_exists(p)
+end
+
+-- Helpers
+local function is_weapon_name(s)
+    return type(s) == "string" and s:upper():find("^WEAPON_") ~= nil
+end
+
+local function trim(s)
+    return type(s) == "string" and (s:gsub("^%s+", ""):gsub("%s+$", "")) or s
+end
+
+-- main scan
+local function scan_crafting_refs()
+    Wait(1500) -- wait a bit for other resources to start up
+
+    local missingDB, missingIMG, malformedReward, checkedDB, checkedIMG = {}, {}, {}, {}, {}
+
+    -- one-time diagnostics
+    print(("^3[script:vorp_crafting]^7 DB adapter detected: ^5%s^7"):format(DB_MODE))
+    if INV_RES_PATH then
+        print(("^3[script:vorp_crafting]^7 inventory icons path: ^5%s/html/img/items^7"):format(INV_RES_PATH))
+    else
+        print("^3[script:vorp_crafting]^7 inventory icons path: ^1NOT FOUND (resource '" .. INV_RES_NAME .. "' missing?)^7")
+    end
+
+    for _, recipe in ipairs(Config.Crafting or {}) do
+        -- 1) Ingredients
+        for __, it in ipairs(recipe.Items or {}) do
+            local nm = trim(it.name)
+            if nm and nm ~= "" then
+                -- DB check (ingredients are always items)
+                if not checkedDB[nm] then
+                    if not db_item_exists(nm) then
+                        missingDB[nm] = true
+                    end
+                    checkedDB[nm] = true
+                end
+
+                -- image check (optional but useful)
+                if INV_RES_PATH and not checkedIMG[nm] then
+                    local exists = image_exists(nm)
+                    if exists == false then
+                        -- Warning: item may be in the database, but PNG was forgotten
+                        -- To avoid duplication with "missed item", log only if there is one in the database
+                        if not missingDB[nm] then
+                            missingIMG[nm] = true
+                        end
+                    end
+                    checkedIMG[nm] = true
+                end
+            else
+                -- name is empty or nil
+                missingDB["<ingredient:empty>"] = true
+            end
+        end
+
+        -- 2) Rewards
+        for __, r in ipairs(recipe.Reward or {}) do
+            local rn = trim(r.name)
+            if not rn or rn == "" then
+                table.insert(malformedReward, recipe.Text or "unknown_recipe")
+            else
+                if recipe.Type == "weapon" and is_weapon_name(rn) then
+                    -- weapon reward → we don't touch the items and pictures database
+                else
+                    -- item reward → DB
+                    if not checkedDB[rn] then
+                        if not db_item_exists(rn) then
+                            missingDB[rn] = true
+                        end
+                        checkedDB[rn] = true
+                    end
+                    -- item reward → PNG
+                    if INV_RES_PATH and not checkedIMG[rn] then
+                        local exists = image_exists(rn)
+                        if exists == false and not missingDB[rn] then
+                            missingIMG[rn] = true
+                        end
+                        checkedIMG[rn] = true
+                    end
+                end
+            end
+        end
+    end
+
+    -- Logs
+    for nm in pairs(missingDB) do
+        print(("^3[script:vorp_crafting]^1 [crafting] missed item in DB: ^7%s"):format(nm))
+    end
+    for nm in pairs(missingIMG) do
+        print(("^3[script:vorp_crafting]^6 [crafting] item has no PNG: ^7%s"):format(nm))
+    end
+    for _, rec in ipairs(malformedReward) do
+        print(("^3[script:vorp_crafting]^1 [crafting] malformed reward (empty name) in recipe: ^7%s"):format(rec))
+    end
+
+    local cDB, cIMG = 0, 0
+    for _ in pairs(missingDB) do cDB = cDB + 1 end
+    for _ in pairs(missingIMG) do cIMG = cIMG + 1 end
+    print(("^2[script:vorp_crafting]^7 scan complete. Missing in DB: ^1%d^7, missing PNG: ^6%d^7."):format(cDB, cIMG))
+end
+
+-- run once on start (give DB adapter a fair chance to initialize)
+CreateThread(function()
+    -- pre-detect DB mode
+    db_item_exists("__probe__") -- fills DB_MODE string
+    scan_crafting_refs()
+end)
+
+-- optional: admin command to rescan without restart (server console only or ACE)
+RegisterCommand("craftscan", function(src)
+    if src ~= 0 and not IsPlayerAceAllowed(src, "command.craftscan") then
+        return
+    end
+    scan_crafting_refs()
+end, true)

--- a/server/server.lua
+++ b/server/server.lua
@@ -332,19 +332,19 @@ local function scan_crafting_refs()
 
     -- Logs
     for nm in pairs(missingDB) do
-        print(("^3[script:vorp_crafting]^1 [crafting] missed item in DB: ^7%s"):format(nm))
+        print(("^1missed item in DB: ^7%s"):format(nm))
     end
     for nm in pairs(missingIMG) do
-        print(("^3[script:vorp_crafting]^6 [crafting] item has no PNG: ^7%s"):format(nm))
+        print(("^6item has no PNG: ^7%s"):format(nm))
     end
     for _, rec in ipairs(malformedReward) do
-        print(("^3[script:vorp_crafting]^1 [crafting] malformed reward (empty name) in recipe: ^7%s"):format(rec))
+        print(("^1malformed reward (empty name) in recipe: ^7%s"):format(rec))
     end
 
     local cDB, cIMG = 0, 0
     for _ in pairs(missingDB) do cDB = cDB + 1 end
     for _ in pairs(missingIMG) do cIMG = cIMG + 1 end
-    print(("^2[script:vorp_crafting]^7 scan complete. Missing in DB: ^1%d^7, missing PNG: ^6%d^7."):format(cDB, cIMG))
+    print(("^7scan complete. Missing in DB: ^1%d^7, missing PNG: ^6%d^7."):format(cDB, cIMG))
 end
 
 -- run once on start (give DB adapter a fair chance to initialize)

--- a/server/server.lua
+++ b/server/server.lua
@@ -199,7 +199,6 @@ local function db_item_exists(name)
     if not name or name == "" then return false end
     local sql = "SELECT 1 FROM items WHERE item = ? LIMIT 1"
 
-    -- oxmysql (preferred)
     if exports.oxmysql then
         if exports.oxmysql.scalarSync then
             DB_MODE = "oxmysql:scalarSync"
@@ -211,23 +210,6 @@ local function db_item_exists(name)
             DB_MODE = "oxmysql:executeSync"
             local ok, rows = pcall(function()
                 return exports.oxmysql:executeSync(sql, { name })
-            end)
-            if ok then return rows and rows[1] ~= nil end
-        end
-    end
-
-    -- mysql-async / ghmattimysql Sync
-    if MySQL and MySQL.Sync then
-        if MySQL.Sync.fetchScalar then
-            DB_MODE = "mysql-async:fetchScalar"
-            local ok, val = pcall(function()
-                return MySQL.Sync.fetchScalar(sql, { name })
-            end)
-            if ok then return val ~= nil end
-        elseif MySQL.Sync.fetchAll then
-            DB_MODE = "mysql-async:fetchAll"
-            local ok, rows = pcall(function()
-                return MySQL.Sync.fetchAll(sql, { name })
             end)
             if ok then return rows and rows[1] ~= nil end
         end
@@ -382,9 +364,8 @@ local function scan_crafting_refs()
 end
 
 -- run once on start (give DB adapter a fair chance to initialize)
-CreateThread(function()
+SetTimeout(1000, function()
     if Config.CraftingDiagnostics then
-        db_item_exists("__probe__")
         scan_crafting_refs()
     end
 end)
@@ -404,10 +385,8 @@ local function db_fetch_all(sql, params)
   if exports.oxmysql and exports.oxmysql.executeSync then
     return exports.oxmysql:executeSync(sql, params or {}) or {}
   end
-  if MySQL and MySQL.Sync and MySQL.Sync.fetchAll then
-    return MySQL.Sync.fetchAll(sql, params or {}) or {}
-  end
-  print("^7 No DB adapter (oxmysql/mysql-async). Item labels will be empty.")
+
+  print("^7 No oxmysql adapter. Item labels will be empty.")
   return {}
 end
 
@@ -537,4 +516,5 @@ AddEventHandler("onResourceStart", function(resName)
       refresh_weapons_into_lut(LabelLUT)
     end)
   end
+
 end)

--- a/server/server.lua
+++ b/server/server.lua
@@ -9,9 +9,12 @@ CreateThread(function()
 end)
 
 Core.Callback.Register("vorp_crafting:GetJob", function(source, cb)
-    local Character = Core.getUser(source).getUsedCharacter
-    local job = Character.job
-    cb(job)
+    local user = Core.getUser(source)
+    if not user or type(user.getUsedCharacter) ~= "function" then
+        cb(nil); return
+    end
+    local char = user.getUsedCharacter()
+    cb(char and char.job or nil)
 end)
 
 RegisterNetEvent('vorp:openInv', function()
@@ -21,7 +24,7 @@ end)
 
 RegisterNetEvent('vorp:startcrafting', function(craftable, countz)
     local _source = source
-    local Character = Core.getUser(_source).getUsedCharacter
+    local Character = Core.getUser(_source).getUsedCharacter()
 
     local Webhook = '' -- Set your webhook URL here
     local function getServerCraftable()
@@ -81,7 +84,7 @@ RegisterNetEvent('vorp:startcrafting', function(craftable, countz)
         }
     end
 
-    local inventory = exports.vorp_inventory:getUserInventoryItems(source)
+    local inventory = exports.vorp_inventory:getUserInventoryItems(_source)
     if not inventory then return end
 
     for _, value in pairs(inventory) do
@@ -109,7 +112,6 @@ RegisterNetEvent('vorp:startcrafting', function(craftable, countz)
             end
         end
     end
-
 
     local craftcheck = true
     for itemName, data in pairs(requiredItems) do
@@ -237,7 +239,12 @@ local function trim(s)
 end
 
 -- main scan
-local LabelLUT = {}
+LabelLUT = LabelLUT or {}
+
+Core.Callback.Register("vorp_crafting:GetLabelLUT", function(source, cb)
+    cb(LabelLUT or {})
+end)
+
 local function is_weapon_name(s) return type(s)=="string" and s:upper():find("^WEAPON_") ~= nil end
 local function lower_or_nil(s) return (type(s)=="string" and s~="") and s:lower() or nil end
 
@@ -361,13 +368,6 @@ local function scan_crafting_refs()
     print("^5[INFO] When all errors are fixed, this debug output will disappear.^7")
 end
 
--- run once on start (give DB adapter a fair chance to initialize)
-if Config.CraftingDiagnostics then
-    SetTimeout(1000, function()
-        scan_crafting_refs()
-    end)
-end
-
 -- =====================================================================
 -- Item Labels LUT for Crafting, Single-init, deduplicated logging.
 -- =====================================================================
@@ -479,26 +479,29 @@ local function init_labels_lut_once()
     if _lut_inited then return end
     _lut_inited = true
 
-    -- register callback once
-    Core.Callback.Register("vorp_crafting:GetLabelLUT", function(source, cb)
-        cb(LabelLUT) -- includes items + weapons
-    end)
-
     -- initial build (items + weapons)
     LabelLUT = {}
     refresh_items_into_lut(LabelLUT)
     refresh_weapons_into_lut(LabelLUT)
 end
 
--- Call init once at load, and also from onResourceStart (guard prevents duplicates)
+-- 1) Labels will always be shown when opening the crafting menu
 init_labels_lut_once()
 
-AddEventHandler("onResourceStart", function(resName)
-    if resName == GetCurrentResourceName() then
-        CreateThread(function()
-            LabelLUT = {}
-            refresh_items_into_lut(LabelLUT)
-            refresh_weapons_into_lut(LabelLUT)
-        end)
-    end
-end)
+-- 2) Diagnostics of missing items in the database, weapons in weapons.lua and images only if Config.CraftingDiagnostics is enabled
+if Config.CraftingDiagnostics then
+    init_labels_lut_once()
+    AddEventHandler("onResourceStart", function(resName)
+        if resName == GetCurrentResourceName() then
+            CreateThread(function()
+                LabelLUT = {}
+                refresh_items_into_lut(LabelLUT)
+                refresh_weapons_into_lut(LabelLUT)
+            end)
+        end
+    end)
+
+    SetTimeout(1000, function()
+        scan_crafting_refs()
+    end)
+end

--- a/server/server.lua
+++ b/server/server.lua
@@ -372,7 +372,6 @@ end
 -- Item Labels LUT for Crafting, Single-init, deduplicated logging.
 -- =====================================================================
 local _lut_inited = false   -- guard to prevent double init
-local _lut_refreshing = false
 
 -- ---------- DB helpers ----------
 local function qmarks(n) local t = {} for i=1,n do t[i]="?" end return table.concat(t, ",") end
@@ -478,30 +477,22 @@ end
 local function init_labels_lut_once()
     if _lut_inited then return end
     _lut_inited = true
-
-    -- initial build (items + weapons)
     LabelLUT = {}
     refresh_items_into_lut(LabelLUT)
     refresh_weapons_into_lut(LabelLUT)
 end
 
--- 1) Labels will always be shown when opening the crafting menu
-init_labels_lut_once()
-
--- 2) Diagnostics of missing items in the database, weapons in weapons.lua and images only if Config.CraftingDiagnostics is enabled
-if Config.CraftingDiagnostics then
+-- Single initialization/re-initialization path at resource start/restart
+AddEventHandler("onResourceStart", function(resName)
+    if resName ~= GetCurrentResourceName() then return end
     init_labels_lut_once()
-    AddEventHandler("onResourceStart", function(resName)
-        if resName == GetCurrentResourceName() then
-            CreateThread(function()
-                LabelLUT = {}
-                refresh_items_into_lut(LabelLUT)
-                refresh_weapons_into_lut(LabelLUT)
-            end)
-        end
-    end)
+    if Config.CraftingDiagnostics then
+        SetTimeout(1000, scan_crafting_refs)
+    end
+end)
 
-    SetTimeout(1000, function()
-        scan_crafting_refs()
-    end)
-end
+-- Callback for the client/services/vui.lua
+Core.Callback.Register("vorp_crafting:GetLabelLUT", function(source, cb)
+    if not _lut_inited then init_labels_lut_once() end
+    cb(LabelLUT or {})
+end)

--- a/server/server.lua
+++ b/server/server.lua
@@ -187,7 +187,9 @@ RegisterNetEvent('vorp:startcrafting', function(craftable, countz)
     end
 end)
 
--- ===== Crafting sanity check (DB + images) =====
+-- =====================================================================
+-- =============== Crafting sanity check (DB + images) =================
+-- =====================================================================
 local INV_RES_NAME = GetConvar("vorp_inventory_resource", "vorp_inventory")
 local INV_RES_PATH = GetResourcePath(INV_RES_NAME) -- absolute path to resource folder (nil if resource not found)
 local DB_MODE = "none"
@@ -242,40 +244,51 @@ local function file_exists(path)
 end
 
 local function image_exists(name)
-    if not INV_RES_PATH then return nil end-- nil => we cannot check (resource not found), we make no noise
+    if not INV_RES_PATH then return nil end -- nil => we cannot check (resource not found), we make no noise
     local p = ("%s/html/img/items/%s.png"):format(INV_RES_PATH, name)
     return file_exists(p)
 end
 
 -- Helpers
-local function is_weapon_name(s)
-    return type(s) == "string" and s:upper():find("^WEAPON_") ~= nil
-end
-
 local function trim(s)
     return type(s) == "string" and (s:gsub("^%s+", ""):gsub("%s+$", "")) or s
 end
 
 -- main scan
+local LabelLUT = {}
+local function is_weapon_name(s) return type(s)=="string" and s:upper():find("^WEAPON_") ~= nil end
+local function lower_or_nil(s) return (type(s)=="string" and s~="") and s:lower() or nil end
+
+local function dump_table_lua(tbl)
+    if type(tbl) ~= "table" then
+        return tostring(tbl)
+    end
+    local parts = {}
+    for k,v in pairs(tbl) do
+        local key = tostring(k)
+        local val
+        if type(v) == "string" then
+            val = string.format("%q", v) -- quoted string
+        else
+            val = tostring(v)
+        end
+        table.insert(parts, key .. " = " .. val)
+    end
+    return "{ " .. table.concat(parts, ", ") .. " }"
+end
+
 local function scan_crafting_refs()
     Wait(1500) -- wait a bit for other resources to start up
 
-    local missingDB, missingIMG, malformedReward, checkedDB, checkedIMG = {}, {}, {}, {}, {}
-
-    -- one-time diagnostics
-    print(("^3[script:vorp_crafting]^7 DB adapter detected: ^5%s^7"):format(DB_MODE))
-    if INV_RES_PATH then
-        print(("^3[script:vorp_crafting]^7 inventory icons path: ^5%s/html/img/items^7"):format(INV_RES_PATH))
-    else
-        print("^3[script:vorp_crafting]^7 inventory icons path: ^1NOT FOUND (resource '" .. INV_RES_NAME .. "' missing?)^7")
-    end
+    local missingDB, missingIMG, malformedReward, missingWeapons = {}, {}, {}, {}
+    local checkedDB, checkedIMG = {}, {}
 
     for _, recipe in ipairs(Config.Crafting or {}) do
         -- 1) Ingredients
         for __, it in ipairs(recipe.Items or {}) do
             local nm = trim(it.name)
             if nm and nm ~= "" then
-                -- DB check (ingredients are always items)
+                -- DB check
                 if not checkedDB[nm] then
                     if not db_item_exists(nm) then
                         missingDB[nm] = true
@@ -283,41 +296,42 @@ local function scan_crafting_refs()
                     checkedDB[nm] = true
                 end
 
-                -- image check (optional but useful)
+                -- PNG check
                 if INV_RES_PATH and not checkedIMG[nm] then
                     local exists = image_exists(nm)
-                    if exists == false then
-                        -- Warning: item may be in the database, but PNG was forgotten
-                        -- To avoid duplication with "missed item", log only if there is one in the database
-                        if not missingDB[nm] then
-                            missingIMG[nm] = true
-                        end
+                    if exists == false and not missingDB[nm] then
+                        missingIMG[nm] = true
                     end
                     checkedIMG[nm] = true
                 end
             else
-                -- name is empty or nil
-                missingDB["<ingredient:empty>"] = true
+                malformedReward[#malformedReward+1] = ("empty ingredient in recipe: %s"):format(recipe.Text or "unknown")
             end
         end
 
         -- 2) Rewards
-        for __, r in ipairs(recipe.Reward or {}) do
+        for ridx, r in ipairs(recipe.Reward or {}) do
             local rn = trim(r.name)
             if not rn or rn == "" then
-                table.insert(malformedReward, recipe.Text or "unknown_recipe")
+                local dump = dump_table_lua(r)
+                local dbg = recipe.Text or ("index="..ridx)
+                malformedReward[#malformedReward+1] =
+                    ("malformed reward in recipe %s → %s"):format(dbg, dump)
             else
                 if recipe.Type == "weapon" and is_weapon_name(rn) then
-                    -- weapon reward → we don't touch the items and pictures database
+                    local wn = lower_or_nil(rn)
+                    if not (LabelLUT[wn] and LabelLUT[wn].label) then
+                        missingWeapons[rn] = true
+                    end
                 else
-                    -- item reward → DB
+                    -- DB check
                     if not checkedDB[rn] then
                         if not db_item_exists(rn) then
                             missingDB[rn] = true
                         end
                         checkedDB[rn] = true
                     end
-                    -- item reward → PNG
+                    -- PNG check
                     if INV_RES_PATH and not checkedIMG[rn] then
                         local exists = image_exists(rn)
                         if exists == false and not missingDB[rn] then
@@ -330,34 +344,197 @@ local function scan_crafting_refs()
         end
     end
 
-    -- Logs
-    for nm in pairs(missingDB) do
-        print(("^1missed item in DB: ^7%s"):format(nm))
-    end
-    for nm in pairs(missingIMG) do
-        print(("^6item has no PNG: ^7%s"):format(nm))
-    end
-    for _, rec in ipairs(malformedReward) do
-        print(("^1malformed reward (empty name) in recipe: ^7%s"):format(rec))
+    -- Exit early if no problems
+    if not next(malformedReward) and not next(missingDB) and not next(missingIMG) and not next(missingWeapons) then
+        return
     end
 
-    local cDB, cIMG = 0, 0
-    for _ in pairs(missingDB) do cDB = cDB + 1 end
-    for _ in pairs(missingIMG) do cIMG = cIMG + 1 end
-    print(("^7scan complete. Missing in DB: ^1%d^7, missing PNG: ^6%d^7."):format(cDB, cIMG))
+    -- Structured logs
+    if #malformedReward > 0 then
+        print("^1[CONFIG] Invalid recipes detected:^7")
+        for _, msg in ipairs(malformedReward) do
+            print("   ^1recipe^7 = "..msg)
+        end
+    end
+
+    if next(missingDB) then
+        print("^1[DATABASE] Missing items in DB:^7")
+        for nm in pairs(missingDB) do
+            print(("   ^1item name^7 = %s"):format(nm))
+        end
+    end
+
+    if next(missingIMG) then
+        print("^6[INVENTORY] Items without PNG icons:^7")
+        for nm in pairs(missingIMG) do
+            print(("   ^6image name^7 = %s"):format(nm))
+        end
+    end
+
+    if next(missingWeapons) then
+        print("^3[INVENTORY] Missing weapons in config/weapons.lua:^7")
+        for nm in pairs(missingWeapons) do
+            print(("   ^3weapon name^7 = %s"):format(nm))
+        end
+    end
+
+    print("^5[INFO] When all errors are fixed, this debug output will disappear.^7")
 end
 
 -- run once on start (give DB adapter a fair chance to initialize)
 CreateThread(function()
-    -- pre-detect DB mode
-    db_item_exists("__probe__") -- fills DB_MODE string
-    scan_crafting_refs()
+    if Config.CraftingDiagnostics then
+        db_item_exists("__probe__")
+        scan_crafting_refs()
+    end
 end)
 
--- optional: admin command to rescan without restart (server console only or ACE)
-RegisterCommand("craftscan", function(src)
-    if src ~= 0 and not IsPlayerAceAllowed(src, "command.craftscan") then
-        return
+-- =====================================================================
+-- Item Labels LUT for Crafting, Single-init, deduplicated logging.
+-- =====================================================================
+local Core = nil
+local _lut_inited = false   -- guard to prevent double init
+local _lut_refreshing = false
+
+-- ---------- DB helpers ----------
+local function qmarks(n) local t = {} for i=1,n do t[i]="?" end return table.concat(t, ",") end
+
+-- DB adapter wrapper
+local function db_fetch_all(sql, params)
+  if exports.oxmysql and exports.oxmysql.executeSync then
+    return exports.oxmysql:executeSync(sql, params or {}) or {}
+  end
+  if MySQL and MySQL.Sync and MySQL.Sync.fetchAll then
+    return MySQL.Sync.fetchAll(sql, params or {}) or {}
+  end
+  print("^7 No DB adapter (oxmysql/mysql-async). Item labels will be empty.")
+  return {}
+end
+
+-- ---------- Collect all item keys from recipes (ingredients + item-type rewards) ----------
+local function collect_item_keys()
+    local set = {}
+    local function add(n)
+        if type(n) == "string" and n ~= "" then set[n:lower()] = true end
     end
-    scan_crafting_refs()
-end, true)
+
+    for _, r in ipairs(Config.Crafting or {}) do
+        for _, it in ipairs(r.Items or {}) do add(it.name) end
+        for _, rw in ipairs(r.Reward or {}) do
+            if not (r.Type == "weapon" and is_weapon_name(rw.name)) then
+                add(rw.name)
+            end
+        end
+    end
+
+    local arr = {}
+    for k in pairs(set) do arr[#arr + 1] = k end
+    table.sort(arr)
+    return arr
+end
+
+-- ---------- Build/Refresh LUT ----------
+local function refresh_items_into_lut(out)
+    local keys = collect_item_keys()
+    if #keys == 0 then
+        return 0, 0
+    end
+
+    local sql = ("SELECT item, label, `desc`, `limit` FROM items WHERE LOWER(item) IN (%s)")
+        :format(qmarks(#keys))
+    local rows = db_fetch_all(sql, keys)
+    local matched, seen = 0, {}
+
+    for _, r in ipairs(rows) do
+        local k = lower_or_nil(r.item)
+        if k and not seen[k] then
+            out[k] = {
+                label = r.label or r.item,
+                desc  = r["desc"] or "",
+                limit = tonumber(r["limit"]) or nil
+            }
+            seen[k] = true
+            matched = matched + 1
+        end
+    end
+
+    return matched, #keys
+end
+
+local function refresh_weapons_into_lut(out)
+    local file = LoadResourceFile(INV_RES_NAME, "config/weapons.lua")
+    if not file then
+        print(("^7 weapons.lua not found in resource '%s' (skipping weapon labels)."):format(INV_RES_NAME))
+        return 0, 0
+    end
+
+    -- run the file in a sandbox to capture SharedData.Weapons
+    local env = { }
+    local chunk, err = load(file, "@weapons.lua", "t", env)
+    if not chunk then
+        print("^7 Failed to load weapons.lua: "..tostring(err))
+        return 0, 0
+    end
+
+    local ok, runtimeErr = pcall(chunk)
+    if not ok then
+        print("^7 Failed to execute weapons.lua: "..tostring(runtimeErr))
+        return 0, 0
+    end
+
+    local W = env.SharedData and env.SharedData.Weapons or {}
+    local matched, total = 0, 0
+    for hash, def in pairs(W) do
+        total = total + 1
+        local k = lower_or_nil(hash)
+        if k and type(def)=="table" then
+        out[k] = out[k] or {} -- don't overwrite DB items
+        out[k].label = def.Name or out[k].label or hash
+        out[k].desc  = def.Desc or out[k].desc or ""
+        out[k].limit = out[k].limit -- keep whatever was there (usually nil for weapons)
+        matched = matched + 1
+        end
+    end
+
+    return matched, total
+end
+
+-- ---------- One-time init (wait for Core, register callback, prime LUT) ----------
+local function init_labels_lut_once()
+    if _lut_inited then return end
+    _lut_inited = true
+
+    -- Single Core init (no duplicates) + unified callback
+    CreateThread(function()
+        -- wait until Core is valid
+        while not Core do
+            Wait(100)
+            Core = exports.vorp_core:GetCore()
+        end
+
+        -- register callback once
+        Core.Callback.Register("vorp_crafting:GetLabelLUT", function(source, cb)
+            cb(LabelLUT) -- includes items + weapons
+        end)
+
+        -- initial build (items + weapons)
+        LabelLUT = {}
+        refresh_items_into_lut(LabelLUT)
+        refresh_weapons_into_lut(LabelLUT)
+    end)
+end
+
+
+-- Call init once at load, and also from onResourceStart (guard prevents duplicates)
+init_labels_lut_once()
+
+AddEventHandler("onResourceStart", function(resName)
+  if resName == GetCurrentResourceName() then
+    CreateThread(function()
+      while not Core do Wait(100) end
+      LabelLUT = {}
+      refresh_items_into_lut(LabelLUT)
+      refresh_weapons_into_lut(LabelLUT)
+    end)
+  end
+end)

--- a/server/server.lua
+++ b/server/server.lua
@@ -23,7 +23,7 @@ RegisterNetEvent('vorp:startcrafting', function(craftable, countz)
     local _source = source
     local Character = Core.getUser(_source).getUsedCharacter
 
-    local Webhook = Config.CraftingWebhook or "" -- Set your webhook URL here
+    local Webhook = '' -- Set your webhook URL here
     local function getServerCraftable()
         local crafting = nil
         for _, v in ipairs(Config.Crafting) do
@@ -260,8 +260,6 @@ local function dump_table_lua(tbl)
 end
 
 local function scan_crafting_refs()
-    Wait(1500) -- wait a bit for other resources to start up
-
     local missingDB, missingIMG, malformedReward, missingWeapons = {}, {}, {}, {}
     local checkedDB, checkedIMG = {}, {}
 
@@ -364,16 +362,15 @@ local function scan_crafting_refs()
 end
 
 -- run once on start (give DB adapter a fair chance to initialize)
-SetTimeout(1000, function()
-    if Config.CraftingDiagnostics then
+if Config.CraftingDiagnostics then
+    SetTimeout(1000, function()
         scan_crafting_refs()
-    end
-end)
+    end)
+end
 
 -- =====================================================================
 -- Item Labels LUT for Crafting, Single-init, deduplicated logging.
 -- =====================================================================
-local Core = nil
 local _lut_inited = false   -- guard to prevent double init
 local _lut_refreshing = false
 
@@ -385,7 +382,6 @@ local function db_fetch_all(sql, params)
   if exports.oxmysql and exports.oxmysql.executeSync then
     return exports.oxmysql:executeSync(sql, params or {}) or {}
   end
-
   print("^7 No oxmysql adapter. Item labels will be empty.")
   return {}
 end
@@ -478,44 +474,31 @@ local function refresh_weapons_into_lut(out)
     return matched, total
 end
 
--- ---------- One-time init (wait for Core, register callback, prime LUT) ----------
+-- ---------- One-time init (register callback, prime LUT) ----------
 local function init_labels_lut_once()
     if _lut_inited then return end
     _lut_inited = true
 
-    -- Single Core init (no duplicates) + unified callback
-    CreateThread(function()
-        -- wait until Core is valid
-        while not Core do
-            Wait(100)
-            Core = exports.vorp_core:GetCore()
-        end
-
-        -- register callback once
-        Core.Callback.Register("vorp_crafting:GetLabelLUT", function(source, cb)
-            cb(LabelLUT) -- includes items + weapons
-        end)
-
-        -- initial build (items + weapons)
-        LabelLUT = {}
-        refresh_items_into_lut(LabelLUT)
-        refresh_weapons_into_lut(LabelLUT)
+    -- register callback once
+    Core.Callback.Register("vorp_crafting:GetLabelLUT", function(source, cb)
+        cb(LabelLUT) -- includes items + weapons
     end)
-end
 
+    -- initial build (items + weapons)
+    LabelLUT = {}
+    refresh_items_into_lut(LabelLUT)
+    refresh_weapons_into_lut(LabelLUT)
+end
 
 -- Call init once at load, and also from onResourceStart (guard prevents duplicates)
 init_labels_lut_once()
 
 AddEventHandler("onResourceStart", function(resName)
-  if resName == GetCurrentResourceName() then
-    CreateThread(function()
-      while not Core do Wait(100) end
-      LabelLUT = {}
-      refresh_items_into_lut(LabelLUT)
-      refresh_weapons_into_lut(LabelLUT)
-    end)
-  end
-
+    if resName == GetCurrentResourceName() then
+        CreateThread(function()
+            LabelLUT = {}
+            refresh_items_into_lut(LabelLUT)
+            refresh_weapons_into_lut(LabelLUT)
+        end)
+    end
 end)
-

--- a/server/server.lua
+++ b/server/server.lua
@@ -23,7 +23,7 @@ RegisterNetEvent('vorp:startcrafting', function(craftable, countz)
     local _source = source
     local Character = Core.getUser(_source).getUsedCharacter
 
-    local Webhook = '' -- Set your webhook URL here
+    local Webhook = Config.CraftingWebhook or "" -- Set your webhook URL here
     local function getServerCraftable()
         local crafting = nil
         for _, v in ipairs(Config.Crafting) do
@@ -518,3 +518,4 @@ AddEventHandler("onResourceStart", function(resName)
   end
 
 end)
+

--- a/ui/app.js
+++ b/ui/app.js
@@ -251,7 +251,13 @@ createApp({
         this.quantity = value
     },
     closeView() {
+      // hard-close everything
+      this.showInput = false;
+      this.activeCraftable = null;
+      this.desc.show = false;
+      this.currentRoute = 'home';
       this.visible = false;
+
       fetch(`https://${GetParentResourceName()}/vorp-craft-close`, {
         method: 'POST'
       })

--- a/ui/app.js
+++ b/ui/app.js
@@ -125,10 +125,42 @@ createApp({
     InputCraftText() {
       return  this.activeCraftable.Text && this.language.InputHeader ? this.language.InputHeader.replace('{{msg}}', this.activeCraftable.Text) : ''
     },
-    Ingredients() {
-      if (this.desc.show == false) return ''
-      return this.desc.data.Desc.replace('Recipe: ', '').replace('Recipe ', '').split(',')
-    }
+    IngredientEntries() {
+      if (!this.desc.show || !this.desc.data) return [];
+      const it = this.desc.data;
+
+      // 1) Advantage of the structure with Config.Crafting
+      if (Array.isArray(it.Items) && it.Items.length > 0) {
+        return it.Items.map(x => {
+          const name = (x.name || '').trim();
+          const count = Number(x.count || 1);
+          return {
+            name,
+            count,
+            img: this.getItemImg(name)
+          };
+        });
+      }
+
+      // 2) Fallback: parse the string Desc ("Recipe: 1x Meat, 1x Salt")
+      const raw = (it.Desc || '')
+        .replace('Recipe:','')
+        .replace('Recipe','')
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean);
+
+      return raw.map(t => {
+        const m = t.match(/(\d+)x\s*(.+)/i);
+        const count = m ? parseInt(m[1], 10) : 1;
+        const name = (m ? m[2] : t).trim();
+        return {
+          name,
+          count,
+          img: this.getItemImg(name)
+        };
+      });
+    },
   },
   methods: {
     getItemImg(name) {

--- a/ui/app.js
+++ b/ui/app.js
@@ -131,6 +131,9 @@ createApp({
     }
   },
   methods: {
+    getItemImg(name) {
+      return `nui://vorp_inventory/html/img/items/${name}.png`;
+    },
     onMessage(event) {
       switch(event.data.type) {
         case "vorp-craft-open":

--- a/ui/app.js
+++ b/ui/app.js
@@ -16,6 +16,7 @@ createApp({
       },
       job: null,
       language: {},
+      labels: {},
       location: {},
       categories: [],
       consumables: {},
@@ -105,66 +106,60 @@ createApp({
   computed: {
     fontClass() {
       let fontc = {}
-
-      switch(this.style.fontSize) {
-        case 's':
-          fontc['smallfont'] = true
-          break;
-        case 'm':
-          fontc['mediumfont'] = true
-          break;
-        case 'l':
-          fontc['largefont'] = true
-          break;
-        default:
-          break; 
+      switch (this.style.fontSize) {
+        case 's': fontc['smallfont']  = true; break;
+        case 'm': fontc['mediumfont'] = true; break;
+        case 'l': fontc['largefont']  = true; break;
+        default: break;
       }
-
       return fontc
     },
     InputCraftText() {
-      return  this.activeCraftable.Text && this.language.InputHeader ? this.language.InputHeader.replace('{{msg}}', this.activeCraftable.Text) : ''
+      const base  = this.language.InputHeader || '';
+      const title = this.activeCraftable ? this.displayName(this.activeCraftable) : '';
+      return base.replace('{{msg}}', title);
     },
     IngredientEntries() {
       if (!this.desc.show || !this.desc.data) return [];
       const it = this.desc.data;
 
-      // 1) Advantage of the structure with Config.Crafting
       if (Array.isArray(it.Items) && it.Items.length > 0) {
         return it.Items.map(x => {
-          const name = (x.name || '').trim();
+          const key   = (x.name || '').trim();
           const count = Number(x.count || 1);
           return {
-            name,
+            key,
+            label: this.labelOf(key),
             count,
-            img: this.getItemImg(name)
+            img: this.getItemImg(key)
           };
         });
       }
-
-      // 2) Fallback: parse the string Desc ("Recipe: 1x Meat, 1x Salt")
-      const raw = (it.Desc || '')
-        .replace('Recipe:','')
-        .replace('Recipe','')
-        .split(',')
-        .map(s => s.trim())
-        .filter(Boolean);
-
-      return raw.map(t => {
-        const m = t.match(/(\d+)x\s*(.+)/i);
-        const count = m ? parseInt(m[1], 10) : 1;
-        const name = (m ? m[2] : t).trim();
-        return {
-          name,
-          count,
-          img: this.getItemImg(name)
-        };
-      });
+      return [];
     },
   },
   methods: {
     getItemImg(name) {
       return `nui://vorp_inventory/html/img/items/${name}.png`;
+    },
+    labelOf(name) {
+      if (!name) return '';
+      const k = String(name).toLowerCase();
+      return this.labels?.[k]?.label || name;
+    },
+    limitOf(name) {
+      if (!name) return null;
+      const k = String(name).toLowerCase();
+      const lim = this.labels?.[k]?.limit;
+      return (typeof lim === 'number') ? lim : null;
+    },
+    rewardName(recipe) {
+      if (!recipe || !Array.isArray(recipe.Reward) || recipe.Reward.length === 0) return '';
+      return recipe.Reward[0].name || '';
+    },
+    displayName(recipe) {
+      const rn = this.rewardName(recipe);
+      return this.labelOf(rn) || rn;
     },
     onMessage(event) {
       switch(event.data.type) {
@@ -251,7 +246,6 @@ createApp({
         this.quantity = value
     },
     closeView() {
-      // hard-close everything
       this.showInput = false;
       this.activeCraftable = null;
       this.desc.show = false;
@@ -263,73 +257,69 @@ createApp({
       })
     },
     setData(data) {
-      let craftables = data.craftables
-      let categories = data.categories
-      let crafttime = data.crafttime
-      let style = data.style
-      let language = data.language
-      let location = data.location
-      let charJob = data.job
+      const craftables = data.craftables || [];
+      const categories = data.categories || [];
+      const crafttime  = data.crafttime;
+      const style      = data.style || {};
+      const language   = data.language || {};
+      const location   = data.location || {};
+      const charJob    = data.job;
+      const labels     = data.labels || data.LabelsLUT || {};
+      const consumables = {};
+      const filteredcat = [];
 
-      let consumables = {}
-      let filteredcat = []
-      // Setup object with keys
+      // Setup categories buckets
       categories.forEach(cat => {
-        consumables[cat.ident] = []
-        let jobcheck = cat.Job === 0 ? true : cat.Job.some(j => j === charJob);
+        consumables[cat.ident] = [];
+        const jobcheck = cat.Job === 0 ? true : cat.Job.some(j => j === charJob);
 
         if (jobcheck) {
           if (cat.Location == 0) {
-            filteredcat.push(cat)
+            filteredcat.push(cat);
           } else {
-            let l = cat.Location.length
-            let pos = 0
-            for (pos; pos < l; pos++) {
-              let loc = cat.Location[pos]
+            const l = cat.Location.length;
+            for (let pos = 0; pos < l; pos++) {
+              const loc = cat.Location[pos];
               if (loc == location?.id) {
-                filteredcat.push(cat)
-                break
+                filteredcat.push(cat);
+                break;
               }
             }
           }
         }
       });
 
-
-
-      // Fill object created above
+      // Fill buckets with craftables
       craftables.forEach(item => {
-        let jobcheck = item.Job === 0 ? true : item.Job.some(j => j === charJob);
+        const jobcheck = item.Job === 0 ? true : item.Job.some(j => j === charJob);
 
         if (jobcheck) {
-          // Filter out locations
           if (item.Location == 0) {
             if (consumables[item.Category]) {
-              consumables[item.Category].push(item)
+              consumables[item.Category].push(item);
             }
           } else {
-            let l = item.Location.length
-            let pos = 0
-            for (pos; pos < l; pos++) {
-              let loc = item.Location[pos]
+            const l = item.Location.length;
+            for (let pos = 0; pos < l; pos++) {
+              const loc = item.Location[pos];
               if (loc == location?.id) {
                 if (consumables[item.Category]) {
-                  consumables[item.Category].push(item)
+                  consumables[item.Category].push(item);
                 }
-                break
+                break;
               }
             }
           }
         }
       });
 
-
-      this.language = language
-      this.consumables = consumables
-      this.categories = filteredcat
-      this.crafttime = crafttime
-      this.style = style
-      this.location = location
-    }
+      this.language    = language;
+      this.labels      = labels;
+      this.consumables = consumables;
+      this.categories  = filteredcat;
+      this.crafttime   = crafttime;
+      this.style       = style;
+      this.location    = location;
+    },
   },
 }).mount("#app");

--- a/ui/index.html
+++ b/ui/index.html
@@ -34,9 +34,10 @@
           </div>
 
           <div class="ing-tile" v-if="desc.show && style.descriptionsidebar == true">
-            <h2>Ingredients</h2>
-            <div v-for="(ing, index) in Ingredients" :key="'desc'+index">
-              {{ing}}
+            <h2>{{ language?.IngredientsHeader || 'Ingredients' }}</h2>
+            <div class="ing-row" v-for="(e, index) in IngredientEntries" :key="'ing'+index">
+              <img class="ing-icon" :src="e.img" @error="($event) => { $event.target.style.display = 'none' }">
+              <span class="ing-text">x{{ e.count }} {{ e.name }}</span>
             </div>
           </div>
         </div>

--- a/ui/index.html
+++ b/ui/index.html
@@ -21,6 +21,7 @@
             <div class="craftable-wrap" v-for="(cata, index) in Object.keys(consumables)" :key="'catitems'+index"   v-show="currentRoute == cata" >
               <div class="bcc-button" v-for="(it, index) in consumables[cata]" @click="handleItemClick(it)" @mouseover="toggleDesc(it, true)" @mouseleave="toggleDesc(null, false)">
                 <div class="button-content">
+                  <img :src="getItemImg(it.Reward[0].name)" class="item-icon">
                   <div class="text">{{it.Text}}</div>
                   <div class="subtext" v-if="it.SubText">{{it.SubText}}</div>
                 </div>

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,60 +1,91 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
+    <meta charset="utf-8" />
     <link rel="stylesheet" href="style.css">
   </head>
   <body>
     <div id="app">
       <div :class="fontClass">
         <div v-show="visible && language" class="panel-wrap">
-          <h1>{{language.CraftHeader}}</h1>
+          <h1>{{ language.CraftHeader }}</h1>
+
           <div class="panel-content">
+            <!-- categories -->
             <div class="categories" v-show="currentRoute == 'home'">
-              <div class="bcc-button" v-for="(cat, index) in categories" :key="cat.ident+index" @click="currentRoute = cat.ident">
-                <span class="statictext">{{cat.text}}</span>
+              <div
+                class="bcc-button"
+                v-for="cat in categories"
+                :key="cat.ident"
+                @click="currentRoute = cat.ident"
+              >
+                <span class="statictext">{{ cat.text }}</span>
               </div>
               <div class="bcc-button" @click="closeView()">
-                <span class="statictext">{{language.ExitButton}}</span>
+                <span class="statictext">{{ language.ExitButton }}</span>
               </div>
             </div>
-  
-            <div class="craftable-wrap" v-for="(cata, index) in Object.keys(consumables)" :key="'catitems'+index"   v-show="currentRoute == cata" >
-              <div class="bcc-button" v-for="(it, index) in consumables[cata]" @click="handleItemClick(it)" @mouseover="toggleDesc(it, true)" @mouseleave="toggleDesc(null, false)">
-                <div class="button-content">
-                  <img :src="getItemImg(it.Reward[0].name)" class="item-icon">
-                  <div class="text">{{it.Text}}</div>
-                  <div class="subtext" v-if="it.SubText">{{it.SubText}}</div>
-                </div>
-                <div v-if="style.descriptionsidebar == false" class="description">
-                  <div>{{it.Desc}}</div>
+
+            <!-- Craftable recipes list -->
+            <div
+              class="craftable-wrap"
+              v-for="cata in Object.keys(consumables)"
+              :key="'cat_'+cata"
+              v-show="currentRoute == cata"
+            >
+              <div
+                class="bcc-button"
+                v-for="it in consumables[cata]"
+                :key="(it.Reward && it.Reward[0] && it.Reward[0].name) || it.Text || JSON.stringify(it)"
+                @click="handleItemClick(it)"
+                @mouseover="toggleDesc(it, true)"
+                @mouseleave="toggleDesc(null, false)"
+              >
+              <div class="button-content">
+                <img :src="getItemImg(rewardName(it))" class="item-icon" @error="e => e.target.style.display='none'" alt="Item icon">
+                <div class="text-wrap">
+                  <div class="text">{{ displayName(it) }}</div>
+                  <div class="subtext" v-if="limitOf(rewardName(it))">MAX = {{ limitOf(rewardName(it)) }}</div>
                 </div>
               </div>
-              <div class="bcc-button" @click="currentRoute = 'home'"><span class="statictext">{{language.BackButton}}</span></div>
+                <div v-if="style.descriptionsidebar == false" class="description">
+                  <div>{{ it.Desc }}</div>
+                </div>
+              </div>
+
+              <div class="bcc-button" @click="currentRoute = 'home'">
+                <span class="statictext">{{ language.BackButton }}</span>
+              </div>
             </div>
           </div>
 
+          <!-- Ingredients sidebar -->
           <div class="ing-tile" v-if="desc.show && style.descriptionsidebar == true">
-            <h2>{{ language?.IngredientsHeader || 'Ingredients' }}</h2>
-            <div class="ing-row" v-for="(e, index) in IngredientEntries" :key="'ing'+index">
-              <img class="ing-icon" :src="e.img" @error="($event) => { $event.target.style.display = 'none' }">
-              <span class="ing-text">x{{ e.count }} {{ e.name }}</span>
+            <h2>{{ (language && language.IngredientsHeader) || 'Ingredients' }}</h2>
+            <div class="ing-row" v-for="(e, i) in IngredientEntries" :key="'ing'+i">
+              <img class="ing-icon" :src="e.img" @error="e => e.target.style.display='none'" :alt="e.label">
+              <span class="ing-text">x{{ e.count }} {{ e.label }}</span>
             </div>
           </div>
         </div>
+
+        <!-- Quantity input -->
         <div v-if="showInput" class="input-wrap">
           <div class="inputs">
-            <div class="message">{{InputCraftText}}</div>
+            <div class="message">{{ InputCraftText }}</div>
             <div class="value-button" id="decrease" @click="decrease">-</div>
             <input type="number" id="number" v-model="quantity" @keyup="formatQuantity" />
             <div class="value-button" id="increase" @click="increase">+</div>
-            <div class="add-button" @click="craftItem">{{language.InputCraft}}{{ quantity > 1 ? 's' : '' }}</div>
-            <div class="cancel-button" @click="showInput = false">{{language.InputCancel}}</div>
+            <div class="add-button" @click="craftItem">
+              {{ language.InputCraft }}{{ quantity > 1 ? 's' : '' }}
+            </div>
+            <div class="cancel-button" @click="showInput = false">{{ language.InputCancel }}</div>
           </div>
         </div>
       </div>
     </div>
+
+    <script src="vendor/vue.js" defer></script>
+    <script src="app.js" defer></script>
   </body>
 </html>
-
-<script src="vendor/vue.js"></script>
-<script src="app.js"></script>

--- a/ui/style.css
+++ b/ui/style.css
@@ -73,6 +73,23 @@ h2 {
   margin-right: 8px;
   vertical-align: middle;
 }
+.ing-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 4px 0;
+}
+
+.ing-icon {
+  max-width: 28px;
+  max-height: 28px;
+  display: inline-block;
+}
+
+.ing-text {
+  line-height: 1.2;
+  font-weight: 600;
+}
 
 /* width */
 ::-webkit-scrollbar {

--- a/ui/style.css
+++ b/ui/style.css
@@ -67,6 +67,13 @@ h2 {
   overflow-y: auto; 
 }
 
+.item-icon {
+  max-height: 48px;
+  max-width: 48px;
+  margin-right: 8px;
+  vertical-align: middle;
+}
+
 /* width */
 ::-webkit-scrollbar {
   width: 2px;

--- a/ui/style.css
+++ b/ui/style.css
@@ -67,30 +67,6 @@ h2 {
   overflow-y: auto; 
 }
 
-.item-icon {
-  max-height: 48px;
-  max-width: 48px;
-  margin-right: 8px;
-  vertical-align: middle;
-}
-.ing-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin: 4px 0;
-}
-
-.ing-icon {
-  max-width: 28px;
-  max-height: 28px;
-  display: inline-block;
-}
-
-.ing-text {
-  line-height: 1.2;
-  font-weight: 600;
-}
-
 /* width */
 ::-webkit-scrollbar {
   width: 2px;
@@ -141,6 +117,20 @@ h2 {
 .button-content {
   width: 100%;
   height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 10px 16px;
+  box-sizing: border-box;
+}
+
+.item-icon {
+  width: 48px;
+  height: 48px;
+  flex: 0 0 48px;
+  object-fit: contain;
+  image-rendering: auto;
 }
 
 .button-content:hover + .description, .description:hover {
@@ -176,8 +166,38 @@ h2 {
   padding: 20px;
 }
 
+.ing-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 6px 0;
+}
+
+.ing-icon {
+  width: 56px;
+  height: 56px;
+  flex: 0 0 56px;
+  object-fit: contain;
+}
+
+.ing-text {
+  line-height: 1.2;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.text-wrap {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  line-height: 1.1;
+}
+
 .text {
-  padding-top: 8px;
+  padding: 0;
+  font-size: 1.25em;
+  white-space: nowrap;
 }
 
 .statictext {
@@ -188,7 +208,11 @@ h2 {
 }
 
 .subtext {
-  color:rgb(28, 99, 171);
+  margin-top: 4px;
+  color: rgb(28, 99, 171);
+  font-size: 0.9em;
+  font-weight: 700;
+  text-transform: uppercase;
 }
 
 .bcc-button:hover {
@@ -432,5 +456,4 @@ input[type=number]::-webkit-outer-spin-button {
     margin: 0;
     width: 100%;
   }
- 
 }


### PR DESCRIPTION
## Type of change
- [x] New feature (non-breaking change which adds functionality)  
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] This change requires a documentation update  

---

### Motive for This Pull Request
Improve the craft UI with quick visual recognition of outputs, and add transparent startup diagnostics so server owners immediately see which items or icons are missing and which craft recipes are malformed.

---

### Provide a brief explanation of why these changes are being proposed and what they aim to achieve
- Craft UI (NUI): renders an item icon before each craftable’s name using  
  `nui://vorp_inventory/html/img/items/<Reward[0].name>.png`.  
  This mirrors the visual style used in stores and makes browsing recipes faster.  

- Closing quantity submenu: added proper handling so pressing *Escape* now also closes the numeric input submenu (quantity selection) in addition to the main crafting panel. Prevents UI elements from “hanging” on screen.

- Server startup diagnostics:  
  - Checks every `Items[].name` and `Reward[].name` referenced by `Config.Crafting` against the `items` table → logs `missed item in DB: <item>`.  
  - Checks for a corresponding PNG file under `vorp_inventory/html/img/items/<item>.png` → logs `item has no PNG: <item>` (only if the DB item exists).  
  - Validates recipe payloads and logs malformed entries (e.g., empty `Reward.name`) → `malformed reward (empty name) in recipe: <recipeText>`.  
  - Logs are deduplicated per item to avoid spam.  

---

### Explain the necessity of these changes and how they will impact the framework or its users
- Players: clearer, faster identification of craft outputs thanks to icons next to recipe names.  
- Admins/Developers: immediate, detailed console feedback on startup about:  
  - missing DB rows for referenced items,  
  - missing inventory icons (PNGs),  
  - invalid or incomplete recipe definitions.  

This shortens setup time and prevents silent UI failures.

---

### Please describe the tests you have conducted to verify your changes
UI (icons):
- Open the crafting menu.  
- Verify each craftable displays an icon to the left of its text.  
- If the PNG exists under `vorp_inventory/html/img/items/<name>.png`, it appears; otherwise, no image is shown (but a server log will indicate the missing PNG).  

UI (submenu close):
- Open a recipe and trigger the quantity selection input.  
- Press *Escape*. Both the main crafting panel and the quantity submenu close correctly.  

Server logging:
- Start the server with your current `Config.Crafting`.  
- Observe the console:  
  - `missed item in DB: <item>` for items not found in the `items` table.  
  - `item has no PNG: <item>` when the DB row exists but the icon file is missing.  
  - `malformed reward (empty name) in recipe: <recipeText>` when a recipe reward is empty/invalid.  
- Add the missing DB item (e.g., `eggs`) and/or drop the corresponding PNG; restart and confirm the warnings are gone.  

Config edge cases:
- For `Type = "weapon"` recipes with `WEAPON_*` rewards, DB/PNG checks are skipped (they’re not inventory items).  

- [x] Tested with latest vorp scripts  
- [x] Tested with latest artifacts  

---

### Notes if any
- For Linux hosts, ensure item keys and PNG filenames match exactly in case (recommended: use lowercase consistently).  
- Logs are printed once per unique item to keep the console clean. Use a quick resource restart to re-run the checks after adding DB rows or PNGs.
